### PR TITLE
Replace point field by cell field for FSI coupling

### DIFF
--- a/FSI/Displacement.C
+++ b/FSI/Displacement.C
@@ -9,10 +9,10 @@ preciceAdapter::FSI::Displacement::Displacement
 )
 :
 pointDisplacement_(
-    const_cast<pointVectorField*>
-    (
-        &mesh.lookupObject<pointVectorField>(namePointDisplacement)
-    )
+const_cast<volVectorField*>
+(
+    &mesh.lookupObject<volVectorField>("cellDisplacement")
+)
 )
 {
     dataType_ = vector;
@@ -42,22 +42,19 @@ void preciceAdapter::FSI::Displacement::read(double * buffer, const unsigned int
         int patchID = patchIDs_.at(j);
 
         // Get the displacement on the patch
-        fixedValuePointPatchVectorField& pointDisplacementFluidPatch
-        (
-            refCast<fixedValuePointPatchVectorField>
-            (
-                pointDisplacement_->boundaryFieldRef()[patchID]
-            )
-        );
+//        volVectorField& pointDisplacementFluidPatch
+//        (
+//                pointDisplacement_->boundaryFieldRef()[patchID]
+//        );
 
         // For every cell of the patch
         forAll(pointDisplacement_->boundaryFieldRef()[patchID], i)
         {
             // Set the displacement to the received one
-            pointDisplacementFluidPatch[i][0] = buffer[bufferIndex++];
-            pointDisplacementFluidPatch[i][1] = buffer[bufferIndex++];
+            pointDisplacement_->boundaryFieldRef()[patchID][i][0] = buffer[bufferIndex++];
+            pointDisplacement_->boundaryFieldRef()[patchID][i][1] = buffer[bufferIndex++];
             if(dim ==3)
-                pointDisplacementFluidPatch[i][2] = buffer[bufferIndex++];
+             pointDisplacement_->boundaryFieldRef()[patchID][i][2] = buffer[bufferIndex++];
         }
     }
 }

--- a/FSI/Displacement.H
+++ b/FSI/Displacement.H
@@ -5,6 +5,8 @@
 
 #include "fvCFD.H"
 #include "fixedValuePointPatchFields.H"
+#include "vectorField.H"
+
 
 namespace preciceAdapter
 {
@@ -18,7 +20,7 @@ class Displacement : public CouplingDataUser
 private:
 
     // Displacement pointVectorField
-    Foam::pointVectorField * pointDisplacement_;
+    Foam::volVectorField * pointDisplacement_;
 
 public:
 


### PR DESCRIPTION
Changing these lines on the adapter side enables to utilize `faceCenters` instead of `faceNodes` for reading displacements for FSI simulations. In order to work properly, the user _must_ provide a file called `cellDisplacement` in addition to the `pointDisplacement` in the initial condition directory `0`. The boundary condition of the `pointDisplacement` field must be changed to, e.g., `type calculated` instead of `fixedValue`. Afterwards reading and writing can be performed on the same mesh on the OpenFOAM side, i.e., both meshes use `faceCenters` and the `precice-config` can be simplified. Although this setup simplifies the overall setup, there are still small differences in the final result (see https://github.com/precice/openfoam-adapter/issues/146#issuecomment-737891372). Before merging this idea the origin of the differences need to be clear (maybe originating from the different mapping).